### PR TITLE
Decode contract errors in Python client

### DIFF
--- a/packages/python/polyplace_contracts/__init__.py
+++ b/packages/python/polyplace_contracts/__init__.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 
+from .errors import PolyplaceContractError
+
 _artifacts_dir = Path(__file__).parent / "artifacts"
 
 
@@ -29,4 +31,5 @@ __all__ = [
     "PLACE_FAUCET_BYTECODE",
     "PLACE_GRID_ABI",
     "PLACE_GRID_BYTECODE",
+    "PolyplaceContractError",
 ]

--- a/packages/python/polyplace_contracts/cli/main.py
+++ b/packages/python/polyplace_contracts/cli/main.py
@@ -7,6 +7,7 @@ There are no defaults: required values raise a clear error when absent.
 from __future__ import annotations
 
 import os
+import sys
 
 import fire
 from eth_account.signers.local import LocalAccount
@@ -20,6 +21,7 @@ from .config import (
     get_token_address,
 )
 from .wrappers import Faucet, Grid, Token
+from polyplace_contracts.errors import PolyplaceContractError
 
 
 class Cli:
@@ -62,7 +64,11 @@ class Cli:
 
 
 def main() -> None:
-    fire.Fire(Cli)
+    try:
+        fire.Fire(Cli)
+    except PolyplaceContractError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from None
 
 
 if __name__ == "__main__":

--- a/packages/python/polyplace_contracts/cli/main.py
+++ b/packages/python/polyplace_contracts/cli/main.py
@@ -12,6 +12,7 @@ import sys
 import fire
 from eth_account.signers.local import LocalAccount
 from web3 import Web3
+from web3.exceptions import ContractLogicError
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from .config import (
@@ -67,6 +68,9 @@ def main() -> None:
     try:
         fire.Fire(Cli)
     except PolyplaceContractError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from None
+    except ContractLogicError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         raise SystemExit(1) from None
 

--- a/packages/python/polyplace_contracts/cli/wrappers.py
+++ b/packages/python/polyplace_contracts/cli/wrappers.py
@@ -7,7 +7,7 @@ from typing import Any
 from eth_account.signers.local import LocalAccount
 from web3 import Web3
 from web3.contract.contract import ContractFunction
-from web3.exceptions import ContractLogicError
+from web3.exceptions import ContractCustomError
 from web3.types import TxReceipt
 
 from polyplace_contracts.errors import translate_contract_error
@@ -44,7 +44,7 @@ class _ContractWrapper:
     def _call(self, name: str, *args: Any) -> Any:
         try:
             return self._contract.functions[name](*args).call()
-        except ContractLogicError as exc:
+        except ContractCustomError as exc:
             raise translate_contract_error(exc) from exc
 
     def _send_fn(self, fn: ContractFunction, **tx_overrides: Any) -> dict[str, Any]:
@@ -60,7 +60,7 @@ class _ContractWrapper:
             tx_hash = self._w3.eth.send_raw_transaction(signed.raw_transaction)
             receipt = self._w3.eth.wait_for_transaction_receipt(tx_hash)
             return _format_receipt(receipt)
-        except ContractLogicError as exc:
+        except ContractCustomError as exc:
             raise translate_contract_error(exc) from exc
 
 

--- a/packages/python/polyplace_contracts/cli/wrappers.py
+++ b/packages/python/polyplace_contracts/cli/wrappers.py
@@ -7,8 +7,10 @@ from typing import Any
 from eth_account.signers.local import LocalAccount
 from web3 import Web3
 from web3.contract.contract import ContractFunction
+from web3.exceptions import ContractLogicError
 from web3.types import TxReceipt
 
+from polyplace_contracts.errors import translate_contract_error
 from polyplace_contracts import (
     PLACE_FAUCET_ABI,
     PLACE_GRID_ABI,
@@ -40,20 +42,27 @@ class _ContractWrapper:
         self._contract = w3.eth.contract(address=Web3.to_checksum_address(address), abi=abi)
 
     def _call(self, name: str, *args: Any) -> Any:
-        return self._contract.functions[name](*args).call()
+        try:
+            return self._contract.functions[name](*args).call()
+        except ContractLogicError as exc:
+            raise translate_contract_error(exc) from exc
 
     def _send_fn(self, fn: ContractFunction, **tx_overrides: Any) -> dict[str, Any]:
         if self._account is None:
             raise RuntimeError("Missing required env var: POLYPLACE_PRIVATE_KEY")
-        tx = fn.build_transaction({
-            "from": self._account.address,
-            "nonce": self._w3.eth.get_transaction_count(self._account.address),
-            **tx_overrides,
-        })
-        signed = self._account.sign_transaction(tx)
-        tx_hash = self._w3.eth.send_raw_transaction(signed.raw_transaction)
-        receipt = self._w3.eth.wait_for_transaction_receipt(tx_hash)
-        return _format_receipt(receipt)
+        try:
+            tx = fn.build_transaction({
+                "from": self._account.address,
+                "nonce": self._w3.eth.get_transaction_count(self._account.address),
+                **tx_overrides,
+            })
+            signed = self._account.sign_transaction(tx)
+            tx_hash = self._w3.eth.send_raw_transaction(signed.raw_transaction)
+            receipt = self._w3.eth.wait_for_transaction_receipt(tx_hash)
+            return _format_receipt(receipt)
+        except ContractLogicError as exc:
+            raise translate_contract_error(exc) from exc
+
 
     def _send(self, name: str, *args: Any, **tx_overrides: Any) -> dict[str, Any]:
         return self._send_fn(self._contract.functions[name](*args), **tx_overrides)

--- a/packages/python/polyplace_contracts/errors.py
+++ b/packages/python/polyplace_contracts/errors.py
@@ -1,0 +1,377 @@
+"""Decode Polyplace contract reverts into readable user-facing errors."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from eth_utils import keccak
+from web3 import Web3
+from web3.exceptions import ContractCustomError, ContractLogicError
+
+_ARTIFACTS_DIR = Path(__file__).parent / "artifacts"
+_GRID_SIZE = 1000
+_PLACE_DECIMALS = Decimal(10) ** 18
+
+
+class PolyplaceContractError(RuntimeError):
+    """Readable contract failure raised by the Python client."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        error_name: str | None = None,
+        data: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.error_name = error_name
+        self.data = data
+
+
+@dataclass(frozen=True)
+class DecodedContractError:
+    name: str
+    arguments: tuple[tuple[str, Any], ...]
+    data: str
+
+
+def translate_contract_error(exc: ContractLogicError) -> PolyplaceContractError:
+    data = extract_contract_error_data(exc)
+    decoded = decode_contract_error_data(data) if data else None
+
+    if decoded is not None:
+        return PolyplaceContractError(
+            format_decoded_contract_error(decoded),
+            error_name=decoded.name,
+            data=decoded.data,
+        )
+
+    if isinstance(exc, ContractCustomError) and data is not None:
+        selector = data[:10]
+        return PolyplaceContractError(
+            f"Contract reverted with an unknown custom error (selector {selector}).",
+            data=data,
+        )
+
+    message = _clean_contract_logic_message(str(exc))
+    if not message:
+        message = "Contract reverted."
+
+    return PolyplaceContractError(message, data=data)
+
+
+def extract_contract_error_data(exc: BaseException) -> str | None:
+    candidates = [getattr(exc, "data", None), exc.args]
+    for candidate in candidates:
+        data = _find_hex_data(candidate)
+        if data is not None:
+            return data
+    return None
+
+
+def decode_contract_error_data(data: str) -> DecodedContractError | None:
+    normalized = _find_hex_data(data)
+    if normalized is None or len(normalized) < 10:
+        return None
+
+    item = _error_registry().get(normalized[2:10])
+    if item is None:
+        return None
+
+    inputs = item.get("inputs", [])
+    try:
+        payload = bytes.fromhex(normalized[10:])
+        decoded_values = tuple(_codec().decode([arg["type"] for arg in inputs], payload)) if inputs else ()
+    except Exception:
+        return None
+
+    arguments: list[tuple[str, Any]] = []
+    for index, (arg, value) in enumerate(zip(inputs, decoded_values)):
+        name = arg.get("name") or f"arg{index}"
+        arguments.append((name, _normalize_decoded_value(value)))
+
+    return DecodedContractError(
+        name=item["name"],
+        arguments=tuple(arguments),
+        data=normalized,
+    )
+
+
+def format_decoded_contract_error(error: DecodedContractError) -> str:
+    args = dict(error.arguments)
+    formatter = _ERROR_FORMATTERS.get(error.name)
+    if formatter is not None:
+        return formatter(args)
+
+    if error.arguments:
+        rendered = ", ".join(f"{name}={_format_value(value)}" for name, value in error.arguments)
+        return f"{error.name}: {rendered}"
+
+    return error.name
+
+
+def _clean_contract_logic_message(message: str) -> str:
+    prefixes = [
+        "execution reverted: ",
+        "execution reverted",
+    ]
+    for prefix in prefixes:
+        if message.startswith(prefix):
+            return message[len(prefix):].strip() or "Contract reverted."
+    return message
+
+
+def _find_hex_data(value: object) -> str | None:
+    if isinstance(value, str):
+        candidate = value.strip().lower()
+        if candidate.startswith("0x") and len(candidate) >= 10 and len(candidate) % 2 == 0:
+            try:
+                bytes.fromhex(candidate[2:])
+            except ValueError:
+                return None
+            return candidate
+        return None
+
+    if isinstance(value, dict):
+        for key in ("data", "result"):
+            data = _find_hex_data(value.get(key))
+            if data is not None:
+                return data
+        for nested in value.values():
+            data = _find_hex_data(nested)
+            if data is not None:
+                return data
+        return None
+
+    if isinstance(value, (list, tuple)):
+        for nested in value:
+            data = _find_hex_data(nested)
+            if data is not None:
+                return data
+
+    return None
+
+
+def _normalize_decoded_value(value: Any) -> Any:
+    if isinstance(value, bytes):
+        return "0x" + value.hex()
+    if isinstance(value, list):
+        return [_normalize_decoded_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_normalize_decoded_value(item) for item in value)
+    return value
+
+
+@lru_cache(maxsize=1)
+def _codec():
+    return Web3().codec
+
+
+@lru_cache(maxsize=1)
+def _error_registry() -> dict[str, dict[str, Any]]:
+    registry: dict[str, dict[str, Any]] = {}
+    for contract_name in ("PlaceToken", "PlaceFaucet", "PlaceGrid"):
+        for item in _load_abi(contract_name):
+            if item.get("type") != "error":
+                continue
+            selector = keccak(text=_error_signature(item))[:4].hex()
+            registry.setdefault(selector, item)
+    return registry
+
+
+def _load_abi(name: str) -> list[dict[str, Any]]:
+    with open(_ARTIFACTS_DIR / f"{name}.json") as f:
+        return json.load(f)["abi"]
+
+
+def _error_signature(item: dict[str, Any]) -> str:
+    arg_types = ",".join(arg["type"] for arg in item.get("inputs", []))
+    return f"{item['name']}({arg_types})"
+
+
+def _format_timestamp(timestamp: int) -> str:
+    try:
+        dt = datetime.fromtimestamp(timestamp, tz=UTC)
+    except (OverflowError, OSError, ValueError):
+        return str(timestamp)
+    return dt.strftime("%Y-%m-%d %H:%M:%SZ")
+
+
+def _format_place(amount: int) -> str:
+    place = Decimal(amount) / _PLACE_DECIMALS
+    text = format(place.normalize(), "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    if not text:
+        text = "0"
+    return f"{text} PLACE ({amount} wei)"
+
+
+def _format_value(value: Any) -> str:
+    if isinstance(value, str) and value.startswith("0x") and len(value) == 42:
+        try:
+            return Web3.to_checksum_address(value)
+        except ValueError:
+            return value
+    if isinstance(value, list):
+        return "[" + ", ".join(_format_value(item) for item in value) + "]"
+    if isinstance(value, tuple):
+        return "(" + ", ".join(_format_value(item) for item in value) + ")"
+    return str(value)
+
+
+def _format_cell(cell_id: int) -> str:
+    x = cell_id % _GRID_SIZE
+    y = cell_id // _GRID_SIZE
+    return f"cell {cell_id} (x={x}, y={y})"
+
+
+def _format_out_of_bounds(args: dict[str, Any]) -> str:
+    return (
+        f"Cell coordinates out of bounds: x={args['x']}, y={args['y']}. "
+        f"Valid range is 0-{_GRID_SIZE - 1}."
+    )
+
+
+def _format_cell_not_available(args: dict[str, Any]) -> str:
+    return (
+        f"{_format_cell(args['cellId'])} is already rented until "
+        f"{_format_timestamp(args['expiresAt'])}."
+    )
+
+
+def _format_not_cell_renter(args: dict[str, Any]) -> str:
+    return (
+        f"You do not currently rent {_format_cell(args['cellId'])}, or its rental has expired."
+    )
+
+
+def _format_invalid_rent_price(_: dict[str, Any]) -> str:
+    return "Rent price must be greater than zero."
+
+
+def _format_invalid_rent_duration(_: dict[str, Any]) -> str:
+    return "Rent duration must be greater than zero."
+
+
+def _format_too_many_cells(args: dict[str, Any]) -> str:
+    return f"Too many cells in one request: {args['count']}. Maximum is 100."
+
+
+def _format_array_length_mismatch(_: dict[str, Any]) -> str:
+    return "The xs, ys, and colors lists must all be the same length."
+
+
+def _format_cooldown(args: dict[str, Any]) -> str:
+    return (
+        "Faucet cooldown has not elapsed. "
+        f"You can claim again at {_format_timestamp(args['availableAt'])}."
+    )
+
+
+def _format_insufficient_faucet_balance(args: dict[str, Any]) -> str:
+    return (
+        "Faucet balance is too low: "
+        f"available {_format_place(args['available'])}, "
+        f"required {_format_place(args['required'])}."
+    )
+
+
+def _format_ownable_invalid_owner(args: dict[str, Any]) -> str:
+    return f"Invalid owner address: {_format_value(args['owner'])}."
+
+
+def _format_ownable_unauthorized(args: dict[str, Any]) -> str:
+    return f"Account {_format_value(args['account'])} is not authorized to perform this action."
+
+
+def _format_safe_erc20_failed(args: dict[str, Any]) -> str:
+    return f"The ERC20 operation failed for token {_format_value(args['token'])}."
+
+
+def _format_erc20_insufficient_allowance(args: dict[str, Any]) -> str:
+    return (
+        "Token allowance is too low for "
+        f"{_format_value(args['spender'])}: allowance {_format_place(args['allowance'])}, "
+        f"required {_format_place(args['needed'])}."
+    )
+
+
+def _format_erc20_insufficient_balance(args: dict[str, Any]) -> str:
+    return (
+        f"Account {_format_value(args['sender'])} has insufficient PLACE balance: "
+        f"balance {_format_place(args['balance'])}, required {_format_place(args['needed'])}."
+    )
+
+
+def _format_invalid_address(role: str, key: str) -> Any:
+    def formatter(args: dict[str, Any]) -> str:
+        return f"Invalid {role} address: {_format_value(args[key])}."
+
+    return formatter
+
+
+def _format_expired_signature(args: dict[str, Any]) -> str:
+    return f"Permit signature expired at {_format_timestamp(args['deadline'])}."
+
+
+def _format_invalid_signer(args: dict[str, Any]) -> str:
+    return (
+        "Permit signature was produced by "
+        f"{_format_value(args['signer'])}, expected {_format_value(args['owner'])}."
+    )
+
+
+def _format_invalid_account_nonce(args: dict[str, Any]) -> str:
+    return (
+        f"Invalid nonce for {_format_value(args['account'])}. "
+        f"Current nonce is {args['currentNonce']}."
+    )
+
+
+def _format_signature_length(args: dict[str, Any]) -> str:
+    return f"Invalid ECDSA signature length: {args['length']} bytes."
+
+
+def _format_signature_s(args: dict[str, Any]) -> str:
+    return f"Invalid ECDSA signature `s` value: {_format_value(args['s'])}."
+
+
+def _format_string_too_long(args: dict[str, Any]) -> str:
+    return f"String is too long: {args['str']!r}."
+
+
+_ERROR_FORMATTERS = {
+    "ArrayLengthMismatch": _format_array_length_mismatch,
+    "CellNotAvailable": _format_cell_not_available,
+    "CooldownNotElapsed": _format_cooldown,
+    "ECDSAInvalidSignature": lambda _args: "Invalid ECDSA signature.",
+    "ECDSAInvalidSignatureLength": _format_signature_length,
+    "ECDSAInvalidSignatureS": _format_signature_s,
+    "ERC20InsufficientAllowance": _format_erc20_insufficient_allowance,
+    "ERC20InsufficientBalance": _format_erc20_insufficient_balance,
+    "ERC20InvalidApprover": _format_invalid_address("approver", "approver"),
+    "ERC20InvalidReceiver": _format_invalid_address("receiver", "receiver"),
+    "ERC20InvalidSender": _format_invalid_address("sender", "sender"),
+    "ERC20InvalidSpender": _format_invalid_address("spender", "spender"),
+    "ERC2612ExpiredSignature": _format_expired_signature,
+    "ERC2612InvalidSigner": _format_invalid_signer,
+    "InsufficientFaucetBalance": _format_insufficient_faucet_balance,
+    "InvalidAccountNonce": _format_invalid_account_nonce,
+    "InvalidRentDuration": _format_invalid_rent_duration,
+    "InvalidRentPrice": _format_invalid_rent_price,
+    "InvalidShortString": lambda _args: "Invalid short string encoding.",
+    "NotCellRenter": _format_not_cell_renter,
+    "OutOfBounds": _format_out_of_bounds,
+    "OwnableInvalidOwner": _format_ownable_invalid_owner,
+    "OwnableUnauthorizedAccount": _format_ownable_unauthorized,
+    "SafeERC20FailedOperation": _format_safe_erc20_failed,
+    "StringTooLong": _format_string_too_long,
+    "TooManyCells": _format_too_many_cells,
+}

--- a/packages/python/tests/test_contract_errors.py
+++ b/packages/python/tests/test_contract_errors.py
@@ -36,50 +36,64 @@ class _DummyContract:
         self.functions = _RaisingFunctions(error_data)
 
 
-class ContractErrorTests(unittest.TestCase):
-    def test_decode_out_of_bounds_data(self) -> None:
-        data = _encode_error("OutOfBounds(uint16,uint16)", ["uint16", "uint16"], [1000, 1000])
+def test_decode_out_of_bounds_data() -> None:
+    data = _encode_error("OutOfBounds(uint16,uint16)", ["uint16", "uint16"], [1000, 1000])
 
-        decoded = decode_contract_error_data(data)
+    decoded = decode_contract_error_data(data)
 
-        self.assertIsNotNone(decoded)
-        self.assertEqual(decoded.name, "OutOfBounds")
-        self.assertEqual(dict(decoded.arguments), {"x": 1000, "y": 1000})
+    assert decoded is not None
+    assert decoded.name == "OutOfBounds"
+    assert dict(decoded.arguments) == {"x": 1000, "y": 1000}
 
-    def test_translate_known_custom_error(self) -> None:
-        data = _encode_error("OutOfBounds(uint16,uint16)", ["uint16", "uint16"], [1000, 1000])
-        exc = ContractCustomError(data, data=data)
 
-        translated = translate_contract_error(exc)
+def test_translate_known_custom_error() -> None:
+    data = _encode_error("OutOfBounds(uint16,uint16)", ["uint16", "uint16"], [1000, 1000])
+    exc = ContractCustomError(data, data=data)
 
-        self.assertIsInstance(translated, PolyplaceContractError)
-        self.assertEqual(
-            str(translated),
-            "Cell coordinates out of bounds: x=1000, y=1000. Valid range is 0-999.",
-        )
-        self.assertEqual(translated.error_name, "OutOfBounds")
+    translated = translate_contract_error(exc)
 
-    def test_translate_unknown_custom_error(self) -> None:
-        data = "0xdeadbeef"
-        exc = ContractCustomError(data, data=data)
+    assert isinstance(translated, PolyplaceContractError)
+    assert str(translated) == "Cell coordinates out of bounds: x=1000, y=1000. Valid range is 0-999."
+    assert translated.error_name == "OutOfBounds"
 
-        translated = translate_contract_error(exc)
 
-        self.assertEqual(
-            str(translated),
-            "Contract reverted with an unknown custom error (selector 0xdeadbeef).",
-        )
-        self.assertIsNone(translated.error_name)
+def test_translate_unknown_custom_error() -> None:
+    data = "0xdeadbeef"
+    exc = ContractCustomError(data, data=data)
 
-    def test_wrapper_rewrites_web3_error(self) -> None:
-        data = _encode_error("CooldownNotElapsed(uint256)", ["uint256"], [1_700_000_000])
-        wrapper = object.__new__(_ContractWrapper)
-        wrapper._contract = _DummyContract(data)
+    translated = translate_contract_error(exc)
 
-        with self.assertRaises(PolyplaceContractError) as raised:
-            wrapper._call("claim")
+    assert str(translated) == "Contract reverted with an unknown custom error (selector 0xdeadbeef)."
+    assert translated.error_name is None
 
-        self.assertIn("Faucet cooldown has not elapsed.", str(raised.exception))
+
+def test_wrapper_rewrites_web3_error() -> None:
+    data = _encode_error("CooldownNotElapsed(uint256)", ["uint256"], [1_700_000_000])
+    wrapper = object.__new__(_ContractWrapper)
+    wrapper._contract = _DummyContract(data)
+
+    try:
+        wrapper._call("claim")
+    except PolyplaceContractError as exc:
+        assert "Faucet cooldown has not elapsed." in str(exc)
+    else:
+        raise AssertionError("Expected PolyplaceContractError to be raised")
+
+
+def load_tests(
+    _loader: unittest.TestLoader,
+    _tests: unittest.TestSuite,
+    _pattern: str | None,
+) -> unittest.TestSuite:
+    suite = unittest.TestSuite()
+    for test in (
+        test_decode_out_of_bounds_data,
+        test_translate_known_custom_error,
+        test_translate_unknown_custom_error,
+        test_wrapper_rewrites_web3_error,
+    ):
+        suite.addTest(unittest.FunctionTestCase(test))
+    return suite
 
 
 if __name__ == "__main__":

--- a/packages/python/tests/test_contract_errors.py
+++ b/packages/python/tests/test_contract_errors.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import unittest
+
+from eth_utils import keccak
+from web3 import Web3
+from web3.exceptions import ContractCustomError
+
+from polyplace_contracts import PolyplaceContractError
+from polyplace_contracts.cli.wrappers import _ContractWrapper
+from polyplace_contracts.errors import decode_contract_error_data, translate_contract_error
+
+
+def _encode_error(signature: str, arg_types: list[str], values: list[object]) -> str:
+    selector = keccak(text=signature)[:4].hex()
+    payload = Web3().codec.encode(arg_types, values).hex() if arg_types else ""
+    return f"0x{selector}{payload}"
+
+
+class _RaisingFunctions:
+    def __init__(self, error_data: str) -> None:
+        self._error_data = error_data
+
+    def __getitem__(self, _name: str) -> "_RaisingFunctions":
+        return self
+
+    def __call__(self, *_args: object) -> "_RaisingFunctions":
+        return self
+
+    def call(self) -> object:
+        raise ContractCustomError(self._error_data, data=self._error_data)
+
+
+class _DummyContract:
+    def __init__(self, error_data: str) -> None:
+        self.functions = _RaisingFunctions(error_data)
+
+
+class ContractErrorTests(unittest.TestCase):
+    def test_decode_out_of_bounds_data(self) -> None:
+        data = _encode_error("OutOfBounds(uint16,uint16)", ["uint16", "uint16"], [1000, 1000])
+
+        decoded = decode_contract_error_data(data)
+
+        self.assertIsNotNone(decoded)
+        self.assertEqual(decoded.name, "OutOfBounds")
+        self.assertEqual(dict(decoded.arguments), {"x": 1000, "y": 1000})
+
+    def test_translate_known_custom_error(self) -> None:
+        data = _encode_error("OutOfBounds(uint16,uint16)", ["uint16", "uint16"], [1000, 1000])
+        exc = ContractCustomError(data, data=data)
+
+        translated = translate_contract_error(exc)
+
+        self.assertIsInstance(translated, PolyplaceContractError)
+        self.assertEqual(
+            str(translated),
+            "Cell coordinates out of bounds: x=1000, y=1000. Valid range is 0-999.",
+        )
+        self.assertEqual(translated.error_name, "OutOfBounds")
+
+    def test_translate_unknown_custom_error(self) -> None:
+        data = "0xdeadbeef"
+        exc = ContractCustomError(data, data=data)
+
+        translated = translate_contract_error(exc)
+
+        self.assertEqual(
+            str(translated),
+            "Contract reverted with an unknown custom error (selector 0xdeadbeef).",
+        )
+        self.assertIsNone(translated.error_name)
+
+    def test_wrapper_rewrites_web3_error(self) -> None:
+        data = _encode_error("CooldownNotElapsed(uint256)", ["uint256"], [1_700_000_000])
+        wrapper = object.__new__(_ContractWrapper)
+        wrapper._contract = _DummyContract(data)
+
+        with self.assertRaises(PolyplaceContractError) as raised:
+            wrapper._call("claim")
+
+        self.assertIn("Faucet cooldown has not elapsed.", str(raised.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- decode ABI-backed custom contract errors into readable user-facing messages
- translate wrapper and CLI failures so raw web3 hex payloads do not leak to users
- add unit tests covering known and unknown custom error decoding

## Testing
- cd packages/python && ./.venv/bin/python -m unittest discover -s tests -v