### PR TITLE
Pin deploy override env vars in Deploy.t.sol

### DIFF
--- a/test/Deploy.t.sol
+++ b/test/Deploy.t.sol
@@ -25,6 +25,20 @@ contract DeployTest is Test {
     function setUp() public {
         // forge-lint: disable-next-line(unsafe-cheatcode)
         vm.setEnv("PRIVATE_KEY", vm.toString(TEST_PRIVATE_KEY));
+        // Pin deploy overrides so a developer's .env (loaded by `just test`)
+        // can't leak public-network values into the in-process script run.
+        // forge-lint: disable-next-line(unsafe-cheatcode)
+        vm.setEnv("POLYPLACE_DEPLOY_CLAIM_AMOUNT", vm.toString(DEPLOY_CLAIM_AMOUNT));
+        // forge-lint: disable-next-line(unsafe-cheatcode)
+        vm.setEnv("POLYPLACE_DEPLOY_COOLDOWN", vm.toString(DEPLOY_COOLDOWN));
+        // forge-lint: disable-next-line(unsafe-cheatcode)
+        vm.setEnv("POLYPLACE_DEPLOY_RENT_PRICE", vm.toString(DEPLOY_RENT_PRICE));
+        // forge-lint: disable-next-line(unsafe-cheatcode)
+        vm.setEnv("POLYPLACE_DEPLOY_RENT_DURATION", vm.toString(DEPLOY_RENT_DURATION));
+        // Empty path keeps the script on its early-return branch and prevents
+        // overwriting .forge-manifests/<network>.json during tests.
+        // forge-lint: disable-next-line(unsafe-cheatcode)
+        vm.setEnv("POLYPLACE_DEPLOYMENT_MANIFEST_PATH", "");
         deployer = vm.addr(TEST_PRIVATE_KEY);
         DeployScript script = new DeployScript();
         (token, faucet, grid) = script.run();


### PR DESCRIPTION
## Summary
- `just test` loads `.env` (via `set dotenv-load`), which can contain public-network overrides like `POLYPLACE_DEPLOY_CLAIM_AMOUNT`/`RENT_PRICE`/`RENT_DURATION`. Those leaked into the in-process `DeployScript.run()` call from `DeployTest.setUp`, breaking three assertions against the in-source `DEPLOY_*` constants.
- Pin all four `POLYPLACE_DEPLOY_*` overrides to the canonical defaults in `setUp` so the test exercises the script's `vm.envOr` branches with controlled inputs.
- Also clear `POLYPLACE_DEPLOYMENT_MANIFEST_PATH` to keep the script on its early-return branch, so `forge test` can never overwrite `.forge-manifests/<network>.json`.

Closes #4.

## Test plan
- [x] `cd polyplace-contracts && just test` passes with the existing local `.env` present (86/86 tests).
- [x] `FOUNDRY_OFFLINE=true forge test` (without dotenv-load) still passes (86/86 tests).
- [x] `.forge-manifests/amoy.json` MD5 unchanged after the test run.