### PR TITLE
Add polyplace-deploy Python library and CLI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-env:
-  FOUNDRY_PROFILE: ci
-
 jobs:
   check:
     name: Foundry project
@@ -24,6 +21,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.5.1
 
       - name: Show Forge version
         run: forge --version

--- a/packages/python/polyplace_contracts/__init__.py
+++ b/packages/python/polyplace_contracts/__init__.py
@@ -24,7 +24,12 @@ PLACE_FAUCET_BYTECODE = _faucet["bytecode"]
 PLACE_GRID_ABI        = _grid["abi"]
 PLACE_GRID_BYTECODE   = _grid["bytecode"]
 
+# Mirrors the `INITIAL_SUPPLY` constant in `src/PlaceToken.sol`. A
+# Solidity-side change is caught by `tests/test_initial_supply.py`.
+INITIAL_SUPPLY = 1_000_000_000 * 10**18
+
 __all__ = [
+    "INITIAL_SUPPLY",
     "PLACE_TOKEN_ABI",
     "PLACE_TOKEN_BYTECODE",
     "PLACE_FAUCET_ABI",

--- a/packages/python/polyplace_contracts/__init__.py
+++ b/packages/python/polyplace_contracts/__init__.py
@@ -24,8 +24,10 @@ PLACE_FAUCET_BYTECODE = _faucet["bytecode"]
 PLACE_GRID_ABI        = _grid["abi"]
 PLACE_GRID_BYTECODE   = _grid["bytecode"]
 
-# Mirrors the `INITIAL_SUPPLY` constant in `src/PlaceToken.sol`. A
-# Solidity-side change is caught by `tests/test_initial_supply.py`.
+# Mirrors the `INITIAL_SUPPLY` constant in `src/PlaceToken.sol`. Drift
+# is caught by `tests/test_deploy.py::test_faucet_holds_initial_supply`,
+# which asserts both `balanceOf(faucet)` and `totalSupply()` against
+# this constant after a real deploy.
 INITIAL_SUPPLY = 1_000_000_000 * 10**18
 
 __all__ = [

--- a/packages/python/polyplace_contracts/cli/deploy.py
+++ b/packages/python/polyplace_contracts/cli/deploy.py
@@ -82,7 +82,18 @@ def main(
     rent_price: int | None,
     rent_duration: int | None,
 ) -> None:
-    """Deploy PlaceToken / PlaceFaucet / PlaceGrid and seed the faucet."""
+    """Deploy PlaceToken / PlaceFaucet / PlaceGrid and seed the faucet.
+
+    By default the shell env block is written to stdout. To load it into
+    your current shell:
+
+    \b
+        eval "$(polyplace-deploy --rpc-url ... --private-key ...)"
+        # or
+        source <(polyplace-deploy --rpc-url ... --private-key ...)
+
+    Pass --env-out PATH to write the block to a file instead.
+    """
     overrides = {
         k: v
         for k, v in {

--- a/packages/python/polyplace_contracts/cli/deploy.py
+++ b/packages/python/polyplace_contracts/cli/deploy.py
@@ -1,7 +1,5 @@
 """`polyplace-deploy` — click-based CLI wrapping `polyplace_contracts.deploy.deploy`."""
 
-from __future__ import annotations
-
 import json
 import sys
 from dataclasses import replace

--- a/packages/python/polyplace_contracts/cli/deploy.py
+++ b/packages/python/polyplace_contracts/cli/deploy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -82,13 +83,17 @@ def main(
     rent_duration: int | None,
 ) -> None:
     """Deploy PlaceToken / PlaceFaucet / PlaceGrid and seed the faucet."""
-    defaults = DeployParams()
-    params = DeployParams(
-        claim_amount=claim_amount if claim_amount is not None else defaults.claim_amount,
-        cooldown=cooldown if cooldown is not None else defaults.cooldown,
-        rent_price=rent_price if rent_price is not None else defaults.rent_price,
-        rent_duration=rent_duration if rent_duration is not None else defaults.rent_duration,
-    )
+    overrides = {
+        k: v
+        for k, v in {
+            "claim_amount": claim_amount,
+            "cooldown": cooldown,
+            "rent_price": rent_price,
+            "rent_duration": rent_duration,
+        }.items()
+        if v is not None
+    }
+    params = replace(DeployParams(), **overrides)
 
     w3 = Web3(Web3.HTTPProvider(rpc_url))
     if not w3.is_connected():

--- a/packages/python/polyplace_contracts/cli/deploy.py
+++ b/packages/python/polyplace_contracts/cli/deploy.py
@@ -1,6 +1,7 @@
 """`polyplace-deploy` — click-based CLI wrapping `polyplace_contracts.deploy.deploy`."""
 
 import json
+import shlex
 import sys
 from dataclasses import replace
 from datetime import datetime, timezone
@@ -37,11 +38,11 @@ def _build_manifest(d: Deployment, name: str | None, created_at: str) -> dict:
 
 def _format_env_block(d: Deployment, rpc_url: str) -> str:
     return (
-        f"export POLYPLACE_RPC_URL={rpc_url}\n"
-        f"export POLYPLACE_TOKEN_ADDRESS={d.token}\n"
-        f"export POLYPLACE_FAUCET_ADDRESS={d.faucet}\n"
-        f"export POLYPLACE_GRID_ADDRESS={d.grid}\n"
-        f"export POLYPLACE_START_BLOCK={d.start_block}\n"
+        f"export POLYPLACE_RPC_URL={shlex.quote(rpc_url)}\n"
+        f"export POLYPLACE_TOKEN_ADDRESS={shlex.quote(d.token)}\n"
+        f"export POLYPLACE_FAUCET_ADDRESS={shlex.quote(d.faucet)}\n"
+        f"export POLYPLACE_GRID_ADDRESS={shlex.quote(d.grid)}\n"
+        f"export POLYPLACE_START_BLOCK={shlex.quote(str(d.start_block))}\n"
     )
 
 

--- a/packages/python/polyplace_contracts/cli/deploy.py
+++ b/packages/python/polyplace_contracts/cli/deploy.py
@@ -1,0 +1,116 @@
+"""`polyplace-deploy` — click-based CLI wrapping `polyplace_contracts.deploy.deploy`."""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import click
+from web3 import Web3
+from web3.middleware import ExtraDataToPOAMiddleware
+
+from polyplace_contracts import INITIAL_SUPPLY
+from polyplace_contracts.deploy import DeployParams, Deployment, deploy
+
+
+def _build_manifest(d: Deployment, name: str | None, created_at: str) -> dict:
+    manifest: dict = {
+        "chainId": d.chain_id,
+        "deployer": d.deployer,
+        "token": d.token,
+        "faucet": d.faucet,
+        "grid": d.grid,
+        "initialSupply": str(INITIAL_SUPPLY),
+        "claimAmount": str(d.params.claim_amount),
+        "cooldown": d.params.cooldown,
+        "rentPrice": str(d.params.rent_price),
+        "rentDuration": d.params.rent_duration,
+        "startBlock": d.start_block,
+        "createdAt": created_at,
+        "txHashes": d.tx_hashes,
+    }
+    if name is not None:
+        manifest["name"] = name
+    return manifest
+
+
+def _format_env_block(d: Deployment, rpc_url: str) -> str:
+    return (
+        f"export POLYPLACE_RPC_URL={rpc_url}\n"
+        f"export POLYPLACE_TOKEN_ADDRESS={d.token}\n"
+        f"export POLYPLACE_FAUCET_ADDRESS={d.faucet}\n"
+        f"export POLYPLACE_GRID_ADDRESS={d.grid}\n"
+        f"export POLYPLACE_START_BLOCK={d.start_block}\n"
+    )
+
+
+@click.command()
+@click.option("--rpc-url", required=True, help="JSON-RPC endpoint to deploy against.")
+@click.option(
+    "--private-key",
+    required=True,
+    envvar="POLYPLACE_PRIVATE_KEY",
+    help="Deployer private key (falls back to POLYPLACE_PRIVATE_KEY).",
+)
+@click.option(
+    "--manifest-out",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Write deployment manifest JSON to this path.",
+)
+@click.option(
+    "--env-out",
+    default=None,
+    help="Write shell env block to this path (use '-' for stdout).",
+)
+@click.option("--name", default=None, help="Optional human label, written into the manifest.")
+@click.option("--claim-amount", type=int, default=None, help="Faucet claim amount (token base units).")
+@click.option("--cooldown", type=int, default=None, help="Faucet cooldown (seconds).")
+@click.option("--rent-price", type=int, default=None, help="Cell rent price (token base units).")
+@click.option("--rent-duration", type=int, default=None, help="Cell rent duration (seconds).")
+def main(
+    rpc_url: str,
+    private_key: str,
+    manifest_out: Path | None,
+    env_out: str | None,
+    name: str | None,
+    claim_amount: int | None,
+    cooldown: int | None,
+    rent_price: int | None,
+    rent_duration: int | None,
+) -> None:
+    """Deploy PlaceToken / PlaceFaucet / PlaceGrid and seed the faucet."""
+    defaults = DeployParams()
+    params = DeployParams(
+        claim_amount=claim_amount if claim_amount is not None else defaults.claim_amount,
+        cooldown=cooldown if cooldown is not None else defaults.cooldown,
+        rent_price=rent_price if rent_price is not None else defaults.rent_price,
+        rent_duration=rent_duration if rent_duration is not None else defaults.rent_duration,
+    )
+
+    w3 = Web3(Web3.HTTPProvider(rpc_url))
+    if not w3.is_connected():
+        raise click.ClickException(f"Cannot connect to RPC at {rpc_url}")
+    w3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
+
+    deployment = deploy(w3, private_key, params)
+    created_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    if manifest_out is not None:
+        manifest = _build_manifest(deployment, name, created_at)
+        manifest_out.parent.mkdir(parents=True, exist_ok=True)
+        manifest_out.write_text(json.dumps(manifest, indent=2) + "\n")
+
+    env_block = _format_env_block(deployment, rpc_url)
+    if env_out is None or env_out == "-":
+        sys.stdout.write(env_block)
+    else:
+        env_path = Path(env_out)
+        env_path.parent.mkdir(parents=True, exist_ok=True)
+        env_path.write_text(env_block)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/python/polyplace_contracts/deploy.py
+++ b/packages/python/polyplace_contracts/deploy.py
@@ -71,9 +71,13 @@ def deploy(
     account: LocalAccount = Account.from_key(deployer_key)
     deployer = account.address
     chain_id = w3.eth.chain_id
-    nonce = w3.eth.get_transaction_count(deployer)
 
-    def _send(tx: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    def _send(builder: Any) -> tuple[str, dict[str, Any]]:
+        tx = builder.build_transaction({
+            "from": deployer,
+            "chainId": chain_id,
+            "nonce": w3.eth.get_transaction_count(deployer),
+        })
         signed = account.sign_transaction(tx)
         tx_hash = w3.eth.send_raw_transaction(signed.raw_transaction)
         receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
@@ -82,15 +86,8 @@ def deploy(
         return tx_hash.hex(), receipt
 
     def _deploy(abi: list, bytecode: str, *args: Any) -> tuple[str, str, dict[str, Any]]:
-        nonlocal nonce
         contract = w3.eth.contract(abi=abi, bytecode=bytecode)
-        tx = contract.constructor(*args).build_transaction({
-            "from": deployer,
-            "nonce": nonce,
-            "chainId": chain_id,
-        })
-        nonce += 1
-        tx_hash, receipt = _send(tx)
+        tx_hash, receipt = _send(contract.constructor(*args))
         return receipt.contractAddress, tx_hash, receipt
 
     token_addr, token_tx, _ = _deploy(PLACE_TOKEN_ABI, PLACE_TOKEN_BYTECODE)
@@ -113,13 +110,7 @@ def deploy(
     )
 
     token = w3.eth.contract(address=token_addr, abi=PLACE_TOKEN_ABI)
-    transfer_tx_dict = token.functions.transfer(faucet_addr, INITIAL_SUPPLY).build_transaction({
-        "from": deployer,
-        "nonce": nonce,
-        "chainId": chain_id,
-    })
-    nonce += 1
-    transfer_tx, transfer_receipt = _send(transfer_tx_dict)
+    transfer_tx, transfer_receipt = _send(token.functions.transfer(faucet_addr, INITIAL_SUPPLY))
 
     return Deployment(
         chain_id=chain_id,

--- a/packages/python/polyplace_contracts/deploy.py
+++ b/packages/python/polyplace_contracts/deploy.py
@@ -5,8 +5,6 @@ talks to the supplied `Web3` instance and signs with the supplied key. The
 caller is responsible for reading any environment, writing manifests, etc.
 """
 
-from __future__ import annotations
-
 from dataclasses import dataclass, field
 from typing import Any
 

--- a/packages/python/polyplace_contracts/deploy.py
+++ b/packages/python/polyplace_contracts/deploy.py
@@ -1,0 +1,142 @@
+"""Pure-Python deployment of the Polyplace contract suite.
+
+This module mirrors `script/Deploy.s.sol` but performs no I/O — it only
+talks to the supplied `Web3` instance and signs with the supplied key. The
+caller is responsible for reading any environment, writing manifests, etc.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from eth_account import Account
+from eth_account.signers.local import LocalAccount
+from web3 import Web3
+
+from polyplace_contracts import (
+    INITIAL_SUPPLY,
+    PLACE_FAUCET_ABI,
+    PLACE_FAUCET_BYTECODE,
+    PLACE_GRID_ABI,
+    PLACE_GRID_BYTECODE,
+    PLACE_TOKEN_ABI,
+    PLACE_TOKEN_BYTECODE,
+)
+
+
+# Defaults match the constants in `script/Deploy.s.sol`.
+_DEFAULT_CLAIM_AMOUNT = 100 * 10**18
+_DEFAULT_COOLDOWN = 86_400
+_DEFAULT_RENT_PRICE = 10 * 10**18
+_DEFAULT_RENT_DURATION = 86_400
+
+
+@dataclass(frozen=True)
+class DeployParams:
+    claim_amount: int = _DEFAULT_CLAIM_AMOUNT
+    cooldown: int = _DEFAULT_COOLDOWN
+    rent_price: int = _DEFAULT_RENT_PRICE
+    rent_duration: int = _DEFAULT_RENT_DURATION
+
+
+@dataclass(frozen=True)
+class Deployment:
+    chain_id: int
+    deployer: str
+    token: str
+    faucet: str
+    grid: str
+    # Block in which `PlaceGrid` was deployed. Indexers backfilling grid
+    # events should start here — earlier blocks cannot contain grid logs.
+    start_block: int
+    # Block of the final `token.transfer(faucet, INITIAL_SUPPLY)` call.
+    deployed_at_block: int
+    params: DeployParams
+    tx_hashes: dict[str, str] = field(default_factory=dict)
+
+
+def deploy(
+    w3: Web3,
+    deployer_key: str,
+    params: DeployParams | None = None,
+) -> Deployment:
+    """Deploy PlaceToken, PlaceFaucet, PlaceGrid and seed the faucet.
+
+    Pure: reads no environment variables and writes no files. Callers wire
+    a configured `Web3` (with any required middleware already attached) and
+    a hex private key; this function signs and broadcasts every transaction.
+    """
+    params = params or DeployParams()
+    account: LocalAccount = Account.from_key(deployer_key)
+    deployer = account.address
+    chain_id = w3.eth.chain_id
+    nonce = w3.eth.get_transaction_count(deployer)
+
+    def _send(tx: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+        signed = account.sign_transaction(tx)
+        tx_hash = w3.eth.send_raw_transaction(signed.raw_transaction)
+        receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
+        if receipt.status != 1:
+            raise RuntimeError(f"Transaction {tx_hash.hex()} reverted")
+        return tx_hash.hex(), receipt
+
+    def _deploy(abi: list, bytecode: str, *args: Any) -> tuple[str, str, dict[str, Any]]:
+        nonlocal nonce
+        contract = w3.eth.contract(abi=abi, bytecode=bytecode)
+        tx = contract.constructor(*args).build_transaction({
+            "from": deployer,
+            "nonce": nonce,
+            "chainId": chain_id,
+        })
+        nonce += 1
+        tx_hash, receipt = _send(tx)
+        return receipt.contractAddress, tx_hash, receipt
+
+    token_addr, token_tx, _ = _deploy(PLACE_TOKEN_ABI, PLACE_TOKEN_BYTECODE)
+    faucet_addr, faucet_tx, _ = _deploy(
+        PLACE_FAUCET_ABI,
+        PLACE_FAUCET_BYTECODE,
+        token_addr,
+        params.claim_amount,
+        params.cooldown,
+        deployer,
+    )
+    grid_addr, grid_tx, grid_receipt = _deploy(
+        PLACE_GRID_ABI,
+        PLACE_GRID_BYTECODE,
+        token_addr,
+        faucet_addr,
+        params.rent_price,
+        params.rent_duration,
+        deployer,
+    )
+
+    token = w3.eth.contract(address=token_addr, abi=PLACE_TOKEN_ABI)
+    transfer_tx_dict = token.functions.transfer(faucet_addr, INITIAL_SUPPLY).build_transaction({
+        "from": deployer,
+        "nonce": nonce,
+        "chainId": chain_id,
+    })
+    nonce += 1
+    transfer_tx, transfer_receipt = _send(transfer_tx_dict)
+
+    return Deployment(
+        chain_id=chain_id,
+        deployer=deployer,
+        token=token_addr,
+        faucet=faucet_addr,
+        grid=grid_addr,
+        start_block=grid_receipt.blockNumber,
+        deployed_at_block=transfer_receipt.blockNumber,
+        params=params,
+        tx_hashes={
+            "token": token_tx,
+            "faucet": faucet_tx,
+            "grid": grid_tx,
+            "transfer": transfer_tx,
+        },
+    )
+
+
+__all__ = ["DeployParams", "Deployment", "deploy"]

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.10"
 dependencies = [
     "web3>=6.0.0",
     "fire>=0.7.1",
+    "click>=8.3.3",
 ]
 
 [project.optional-dependencies]
@@ -15,6 +16,7 @@ dev = [
 
 [project.scripts]
 polyplace-dev = "polyplace_contracts.cli:main"
+polyplace-deploy = "polyplace_contracts.cli.deploy:main"
 
 [build-system]
 requires = ["setuptools>=61"]

--- a/packages/python/tests/conftest.py
+++ b/packages/python/tests/conftest.py
@@ -1,7 +1,5 @@
 """Shared fixtures: spin up a local Anvil chain for tests that need a real EVM."""
 
-from __future__ import annotations
-
 import socket
 import subprocess
 import time

--- a/packages/python/tests/conftest.py
+++ b/packages/python/tests/conftest.py
@@ -1,0 +1,63 @@
+"""Shared fixtures: spin up a local Anvil chain for tests that need a real EVM."""
+
+from __future__ import annotations
+
+import socket
+import subprocess
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import pytest
+from web3 import Web3
+
+
+# anvil's first default funded account; private key matches the canonical
+# `anvil --accounts 10` mnemonic. Fine for tests; never use in production.
+ANVIL_DEFAULT_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+
+@dataclass(frozen=True)
+class AnvilNode:
+    rpc_url: str
+    deployer_key: str
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_rpc(url: str, timeout: float = 10.0) -> None:
+    w3 = Web3(Web3.HTTPProvider(url))
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            if w3.is_connected():
+                return
+        except Exception:
+            pass
+        time.sleep(0.1)
+    raise RuntimeError(f"Anvil never became reachable at {url}")
+
+
+@pytest.fixture
+def anvil() -> Iterator[AnvilNode]:
+    port = _free_port()
+    proc = subprocess.Popen(
+        ["anvil", "--port", str(port), "--silent"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        url = f"http://127.0.0.1:{port}"
+        _wait_for_rpc(url)
+        yield AnvilNode(rpc_url=url, deployer_key=ANVIL_DEFAULT_KEY)
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()

--- a/packages/python/tests/test_deploy.py
+++ b/packages/python/tests/test_deploy.py
@@ -2,6 +2,8 @@
 
 import os
 import re
+import shlex
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -14,8 +16,8 @@ from polyplace_contracts import (
     PLACE_GRID_ABI,
     PLACE_TOKEN_ABI,
 )
-from polyplace_contracts.cli.deploy import main as deploy_cli
-from polyplace_contracts.deploy import DeployParams, deploy
+from polyplace_contracts.cli.deploy import _format_env_block, main as deploy_cli
+from polyplace_contracts.deploy import DeployParams, Deployment, deploy
 
 from conftest import AnvilNode
 
@@ -153,3 +155,36 @@ def test_cli_writes_manifest(anvil: AnvilNode, tmp_path: Path) -> None:
     for key in ("token", "faucet", "grid", "deployer", "startBlock", "createdAt", "txHashes"):
         assert key in manifest, f"manifest missing {key}"
     assert set(manifest["txHashes"]) == {"token", "faucet", "grid", "transfer"}
+
+
+def test_env_block_shell_quotes_rpc_url(tmp_path: Path) -> None:
+    rpc_url = "https://rpc.example/?apiKey=abc&project=1"
+    deployment = Deployment(
+        chain_id=31337,
+        deployer="0x" + "11" * 20,
+        token="0x" + "22" * 20,
+        faucet="0x" + "33" * 20,
+        grid="0x" + "44" * 20,
+        start_block=123,
+        deployed_at_block=124,
+        params=DeployParams(),
+        tx_hashes={},
+    )
+    env_path = tmp_path / "deploy.env"
+    env_path.write_text(_format_env_block(deployment, rpc_url))
+
+    result = subprocess.run(
+        [
+            "/bin/sh",
+            "-c",
+            (
+                f". {shlex.quote(str(env_path))}; "
+                "printf '%s\\n%s\\n' \"$POLYPLACE_RPC_URL\" \"$POLYPLACE_START_BLOCK\""
+            ),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.splitlines() == [rpc_url, str(deployment.start_block)]

--- a/packages/python/tests/test_deploy.py
+++ b/packages/python/tests/test_deploy.py
@@ -1,7 +1,5 @@
 """End-to-end deploy tests against a local Anvil chain."""
 
-from __future__ import annotations
-
 import os
 import re
 from pathlib import Path

--- a/packages/python/tests/test_deploy.py
+++ b/packages/python/tests/test_deploy.py
@@ -1,0 +1,157 @@
+"""End-to-end deploy tests against a local Anvil chain."""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from web3 import Web3
+
+from polyplace_contracts import (
+    INITIAL_SUPPLY,
+    PLACE_FAUCET_ABI,
+    PLACE_GRID_ABI,
+    PLACE_TOKEN_ABI,
+)
+from polyplace_contracts.cli.deploy import main as deploy_cli
+from polyplace_contracts.deploy import DeployParams, deploy
+
+from conftest import AnvilNode
+
+
+def _w3(node: AnvilNode) -> Web3:
+    return Web3(Web3.HTTPProvider(node.rpc_url))
+
+
+def test_deploy_returns_three_addresses(anvil: AnvilNode) -> None:
+    w3 = _w3(anvil)
+
+    deployment = deploy(w3, anvil.deployer_key)
+
+    for addr in (deployment.token, deployment.faucet, deployment.grid):
+        assert w3.eth.get_code(addr) != b"", f"no code at {addr}"
+
+
+def test_faucet_holds_initial_supply(anvil: AnvilNode) -> None:
+    w3 = _w3(anvil)
+
+    deployment = deploy(w3, anvil.deployer_key)
+
+    token = w3.eth.contract(address=deployment.token, abi=PLACE_TOKEN_ABI)
+    assert token.functions.balanceOf(deployment.faucet).call() == INITIAL_SUPPLY
+    assert token.functions.totalSupply().call() == INITIAL_SUPPLY
+
+
+def test_params_passed_through(anvil: AnvilNode) -> None:
+    w3 = _w3(anvil)
+    custom = DeployParams(
+        claim_amount=42 * 10**18,
+        cooldown=3600,
+        rent_price=7 * 10**18,
+        rent_duration=7200,
+    )
+
+    deployment = deploy(w3, anvil.deployer_key, custom)
+
+    faucet = w3.eth.contract(address=deployment.faucet, abi=PLACE_FAUCET_ABI)
+    grid = w3.eth.contract(address=deployment.grid, abi=PLACE_GRID_ABI)
+    assert faucet.functions.claimAmount().call() == custom.claim_amount
+    assert faucet.functions.cooldown().call() == custom.cooldown
+    assert grid.functions.rentPrice().call() == custom.rent_price
+    assert grid.functions.rentDuration().call() == custom.rent_duration
+    assert deployment.params == custom
+
+
+def test_start_block_is_grid_deploy_block(anvil: AnvilNode) -> None:
+    w3 = _w3(anvil)
+
+    deployment = deploy(w3, anvil.deployer_key)
+
+    grid_tx_hash = deployment.tx_hashes["grid"]
+    grid_receipt = w3.eth.get_transaction_receipt(grid_tx_hash)
+    assert deployment.start_block == grid_receipt.blockNumber
+
+
+def test_deploy_is_pure(anvil: AnvilNode, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    for var in [
+        "POLYPLACE_RPC_URL",
+        "POLYPLACE_TOKEN_ADDRESS",
+        "POLYPLACE_FAUCET_ADDRESS",
+        "POLYPLACE_GRID_ADDRESS",
+        "POLYPLACE_PRIVATE_KEY",
+        "POLYPLACE_DEPLOYMENT_MANIFEST_PATH",
+        "PRIVATE_KEY",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    before = set(os.listdir(tmp_path))
+
+    deploy(_w3(anvil), anvil.deployer_key)
+
+    assert set(os.listdir(tmp_path)) == before
+
+
+def test_cli_prints_env_block_to_stdout(anvil: AnvilNode) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        deploy_cli,
+        [
+            "--rpc-url",
+            anvil.rpc_url,
+            "--private-key",
+            anvil.deployer_key,
+            "--env-out",
+            "-",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    env = dict(re.findall(r"^export (\w+)=(\S+)$", result.output, flags=re.MULTILINE))
+    assert env["POLYPLACE_RPC_URL"] == anvil.rpc_url
+    for key in (
+        "POLYPLACE_TOKEN_ADDRESS",
+        "POLYPLACE_FAUCET_ADDRESS",
+        "POLYPLACE_GRID_ADDRESS",
+        "POLYPLACE_START_BLOCK",
+    ):
+        assert key in env, f"missing {key} in CLI output"
+    w3 = _w3(anvil)
+    for key in ("POLYPLACE_TOKEN_ADDRESS", "POLYPLACE_FAUCET_ADDRESS", "POLYPLACE_GRID_ADDRESS"):
+        assert w3.eth.get_code(env[key]) != b""
+
+
+def test_cli_writes_manifest(anvil: AnvilNode, tmp_path: Path) -> None:
+    runner = CliRunner()
+    manifest_path = tmp_path / "out" / "local.json"
+
+    result = runner.invoke(
+        deploy_cli,
+        [
+            "--rpc-url",
+            anvil.rpc_url,
+            "--private-key",
+            anvil.deployer_key,
+            "--manifest-out",
+            str(manifest_path),
+            "--name",
+            "anvil-test",
+            "--rent-price",
+            str(5 * 10**18),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    import json
+
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["chainId"] == 31337
+    assert manifest["name"] == "anvil-test"
+    assert manifest["rentPrice"] == str(5 * 10**18)
+    assert manifest["initialSupply"] == str(INITIAL_SUPPLY)
+    for key in ("token", "faucet", "grid", "deployer", "startBlock", "createdAt", "txHashes"):
+        assert key in manifest, f"manifest missing {key}"
+    assert set(manifest["txHashes"]) == {"token", "faucet", "grid", "transfer"}

--- a/packages/python/uv.lock
+++ b/packages/python/uv.lock
@@ -428,6 +428,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1063,6 +1075,7 @@ name = "polyplace-contracts"
 version = "0.3.0"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "fire" },
     { name = "web3" },
 ]
@@ -1074,6 +1087,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.3.3" },
     { name = "fire", specifier = ">=0.7.1" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "web3", specifier = ">=6.0.0" },


### PR DESCRIPTION
## Summary

- New `polyplace_contracts.deploy` module: pure `deploy(w3, key, params)` returning a `Deployment` dataclass with addresses, `start_block` (the `PlaceGrid` deploy block, what the watcher needs for backfill), `deployed_at_block`, params, and per-tx hashes.
- New `polyplace-deploy` click CLI registered as a console script. Connects via `--rpc-url`, signs with `--private-key` (or `POLYPLACE_PRIVATE_KEY`), supports param overrides, writes a manifest with `--manifest-out`, and prints/writes a shell env block (`POLYPLACE_RPC_URL`, `POLYPLACE_TOKEN_ADDRESS`, `POLYPLACE_FAUCET_ADDRESS`, `POLYPLACE_GRID_ADDRESS`, `POLYPLACE_START_BLOCK`).
- `INITIAL_SUPPLY` re-exported from `polyplace_contracts`; library is I/O-free (no env reads, no file writes).
- Tests run against an in-process Anvil fixture and cover address presence, faucet seeding, param pass-through, `start_block` semantics, library purity, and CLI smoke (env-block + manifest).

Closes [#10](https://github.com/josh-gree/polyplace-contracts/issues/10)

## Test plan

- [x] `uv run pytest tests/` — 11 passed against local Anvil
- [x] `uv run polyplace-deploy --help` shows expected options
- [ ] Reviewer: spot-check manifest schema vs `.forge-manifests/amoy.json` (adds `name`, `startBlock`, `createdAt`, `txHashes`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)