### PR TITLE
Add Python CI: ruff lint/format + pytest

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,43 @@
+name: Python CI
+
+permissions: {}
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  check:
+    name: Python package
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: packages/python
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Sync dependencies
+        run: uv sync --extra dev
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.5.1
+
+      - name: Ruff lint
+        run: uv run ruff check .
+
+      - name: Ruff format check
+        run: uv run ruff format --check .
+
+      - name: Pytest
+        run: uv run pytest

--- a/packages/python/polyplace_contracts/__init__.py
+++ b/packages/python/polyplace_contracts/__init__.py
@@ -11,18 +11,18 @@ def _load(name: str) -> dict:
         return json.load(f)
 
 
-_token  = _load("PlaceToken")
+_token = _load("PlaceToken")
 _faucet = _load("PlaceFaucet")
-_grid   = _load("PlaceGrid")
+_grid = _load("PlaceGrid")
 
-PLACE_TOKEN_ABI       = _token["abi"]
-PLACE_TOKEN_BYTECODE  = _token["bytecode"]
+PLACE_TOKEN_ABI = _token["abi"]
+PLACE_TOKEN_BYTECODE = _token["bytecode"]
 
-PLACE_FAUCET_ABI      = _faucet["abi"]
+PLACE_FAUCET_ABI = _faucet["abi"]
 PLACE_FAUCET_BYTECODE = _faucet["bytecode"]
 
-PLACE_GRID_ABI        = _grid["abi"]
-PLACE_GRID_BYTECODE   = _grid["bytecode"]
+PLACE_GRID_ABI = _grid["abi"]
+PLACE_GRID_BYTECODE = _grid["bytecode"]
 
 # Mirrors the `INITIAL_SUPPLY` constant in `src/PlaceToken.sol`. Drift
 # is caught by `tests/test_deploy.py::test_faucet_holds_initial_supply`,

--- a/packages/python/polyplace_contracts/cli/deploy.py
+++ b/packages/python/polyplace_contracts/cli/deploy.py
@@ -12,7 +12,7 @@ from web3 import Web3
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from polyplace_contracts import INITIAL_SUPPLY
-from polyplace_contracts.deploy import DeployParams, Deployment, deploy
+from polyplace_contracts.deploy import Deployment, DeployParams, deploy
 
 
 def _build_manifest(d: Deployment, name: str | None, created_at: str) -> dict:
@@ -66,7 +66,9 @@ def _format_env_block(d: Deployment, rpc_url: str) -> str:
     help="Write shell env block to this path (use '-' for stdout).",
 )
 @click.option("--name", default=None, help="Optional human label, written into the manifest.")
-@click.option("--claim-amount", type=int, default=None, help="Faucet claim amount (token base units).")
+@click.option(
+    "--claim-amount", type=int, default=None, help="Faucet claim amount (token base units)."
+)
 @click.option("--cooldown", type=int, default=None, help="Faucet cooldown (seconds).")
 @click.option("--rent-price", type=int, default=None, help="Cell rent price (token base units).")
 @click.option("--rent-duration", type=int, default=None, help="Cell rent duration (seconds).")

--- a/packages/python/polyplace_contracts/cli/main.py
+++ b/packages/python/polyplace_contracts/cli/main.py
@@ -15,6 +15,8 @@ from web3 import Web3
 from web3.exceptions import ContractLogicError
 from web3.middleware import ExtraDataToPOAMiddleware
 
+from polyplace_contracts.errors import PolyplaceContractError
+
 from .config import (
     get_faucet_address,
     get_grid_address,
@@ -22,7 +24,6 @@ from .config import (
     get_token_address,
 )
 from .wrappers import Faucet, Grid, Token
-from polyplace_contracts.errors import PolyplaceContractError
 
 
 class Cli:

--- a/packages/python/polyplace_contracts/cli/wrappers.py
+++ b/packages/python/polyplace_contracts/cli/wrappers.py
@@ -10,12 +10,12 @@ from web3.contract.contract import ContractFunction
 from web3.exceptions import ContractCustomError
 from web3.types import TxReceipt
 
-from polyplace_contracts.errors import translate_contract_error
 from polyplace_contracts import (
     PLACE_FAUCET_ABI,
     PLACE_GRID_ABI,
     PLACE_TOKEN_ABI,
 )
+from polyplace_contracts.errors import translate_contract_error
 
 from .color import parse_color
 
@@ -51,18 +51,19 @@ class _ContractWrapper:
         if self._account is None:
             raise RuntimeError("Missing required env var: POLYPLACE_PRIVATE_KEY")
         try:
-            tx = fn.build_transaction({
-                "from": self._account.address,
-                "nonce": self._w3.eth.get_transaction_count(self._account.address),
-                **tx_overrides,
-            })
+            tx = fn.build_transaction(
+                {
+                    "from": self._account.address,
+                    "nonce": self._w3.eth.get_transaction_count(self._account.address),
+                    **tx_overrides,
+                }
+            )
             signed = self._account.sign_transaction(tx)
             tx_hash = self._w3.eth.send_raw_transaction(signed.raw_transaction)
             receipt = self._w3.eth.wait_for_transaction_receipt(tx_hash)
             return _format_receipt(receipt)
         except ContractCustomError as exc:
             raise translate_contract_error(exc) from exc
-
 
     def _send(self, name: str, *args: Any, **tx_overrides: Any) -> dict[str, Any]:
         return self._send_fn(self._contract.functions[name](*args), **tx_overrides)
@@ -182,14 +183,10 @@ class Grid(_ContractWrapper):
     def set_color(self, x: int, y: int, color: str) -> dict[str, Any]:
         return self._send("setColor", x, y, parse_color(color))
 
-    def bulk_rent_cells(
-        self, xs: list[int], ys: list[int], colors: list[str]
-    ) -> dict[str, Any]:
+    def bulk_rent_cells(self, xs: list[int], ys: list[int], colors: list[str]) -> dict[str, Any]:
         return self._send("bulkRentCells", xs, ys, [parse_color(c) for c in colors])
 
-    def bulk_set_colors(
-        self, xs: list[int], ys: list[int], colors: list[str]
-    ) -> dict[str, Any]:
+    def bulk_set_colors(self, xs: list[int], ys: list[int], colors: list[str]) -> dict[str, Any]:
         return self._send("bulkSetColors", xs, ys, [parse_color(c) for c in colors])
 
     def set_rent_price(self, new_price: int) -> dict[str, Any]:

--- a/packages/python/polyplace_contracts/deploy.py
+++ b/packages/python/polyplace_contracts/deploy.py
@@ -22,7 +22,6 @@ from polyplace_contracts import (
     PLACE_TOKEN_BYTECODE,
 )
 
-
 # Defaults match the constants in `script/Deploy.s.sol`.
 _DEFAULT_CLAIM_AMOUNT = 100 * 10**18
 _DEFAULT_COOLDOWN = 86_400
@@ -71,11 +70,13 @@ def deploy(
     chain_id = w3.eth.chain_id
 
     def _send(builder: Any) -> tuple[str, dict[str, Any]]:
-        tx = builder.build_transaction({
-            "from": deployer,
-            "chainId": chain_id,
-            "nonce": w3.eth.get_transaction_count(deployer),
-        })
+        tx = builder.build_transaction(
+            {
+                "from": deployer,
+                "chainId": chain_id,
+                "nonce": w3.eth.get_transaction_count(deployer),
+            }
+        )
         signed = account.sign_transaction(tx)
         tx_hash = w3.eth.send_raw_transaction(signed.raw_transaction)
         receipt = w3.eth.wait_for_transaction_receipt(tx_hash)

--- a/packages/python/polyplace_contracts/errors.py
+++ b/packages/python/polyplace_contracts/errors.py
@@ -87,7 +87,9 @@ def decode_contract_error_data(data: str) -> DecodedContractError | None:
     inputs = item.get("inputs", [])
     try:
         payload = bytes.fromhex(normalized[10:])
-        decoded_values = tuple(_codec().decode([arg["type"] for arg in inputs], payload)) if inputs else ()
+        decoded_values = (
+            tuple(_codec().decode([arg["type"] for arg in inputs], payload)) if inputs else ()
+        )
     except Exception:
         return None
 
@@ -123,7 +125,7 @@ def _clean_contract_logic_message(message: str) -> str:
     ]
     for prefix in prefixes:
         if message.startswith(prefix):
-            return message[len(prefix):].strip() or "Contract reverted."
+            return message[len(prefix) :].strip() or "Contract reverted."
     return message
 
 
@@ -247,9 +249,7 @@ def _format_cell_not_available(args: dict[str, Any]) -> str:
 
 
 def _format_not_cell_renter(args: dict[str, Any]) -> str:
-    return (
-        f"You do not currently rent {_format_cell(args['cellId'])}, or its rental has expired."
-    )
+    return f"You do not currently rent {_format_cell(args['cellId'])}, or its rental has expired."
 
 
 def _format_invalid_rent_price(_: dict[str, Any]) -> str:

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -27,3 +27,15 @@ where = ["."]
 
 [tool.setuptools.package-data]
 polyplace_contracts = ["artifacts/*.json"]
+
+[dependency-groups]
+dev = [
+    "ruff>=0.15.12",
+]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+extend-select = ["I", "UP"]

--- a/packages/python/tests/conftest.py
+++ b/packages/python/tests/conftest.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 import pytest
 from web3 import Web3
 
-
 # anvil's first default funded account; private key matches the canonical
 # `anvil --accounts 10` mnemonic. Fine for tests; never use in production.
 ANVIL_DEFAULT_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"

--- a/packages/python/tests/test_contract_errors.py
+++ b/packages/python/tests/test_contract_errors.py
@@ -21,10 +21,10 @@ class _RaisingFunctions:
     def __init__(self, error_data: str) -> None:
         self._error_data = error_data
 
-    def __getitem__(self, _name: str) -> "_RaisingFunctions":
+    def __getitem__(self, _name: str) -> _RaisingFunctions:
         return self
 
-    def __call__(self, *_args: object) -> "_RaisingFunctions":
+    def __call__(self, *_args: object) -> _RaisingFunctions:
         return self
 
     def call(self) -> object:
@@ -53,7 +53,9 @@ def test_translate_known_custom_error() -> None:
     translated = translate_contract_error(exc)
 
     assert isinstance(translated, PolyplaceContractError)
-    assert str(translated) == "Cell coordinates out of bounds: x=1000, y=1000. Valid range is 0-999."
+    assert (
+        str(translated) == "Cell coordinates out of bounds: x=1000, y=1000. Valid range is 0-999."
+    )
     assert translated.error_name == "OutOfBounds"
 
 
@@ -63,7 +65,9 @@ def test_translate_unknown_custom_error() -> None:
 
     translated = translate_contract_error(exc)
 
-    assert str(translated) == "Contract reverted with an unknown custom error (selector 0xdeadbeef)."
+    assert (
+        str(translated) == "Contract reverted with an unknown custom error (selector 0xdeadbeef)."
+    )
     assert translated.error_name is None
 
 

--- a/packages/python/tests/test_deploy.py
+++ b/packages/python/tests/test_deploy.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
+from conftest import AnvilNode
 from web3 import Web3
 
 from polyplace_contracts import (
@@ -16,10 +17,9 @@ from polyplace_contracts import (
     PLACE_GRID_ABI,
     PLACE_TOKEN_ABI,
 )
-from polyplace_contracts.cli.deploy import _format_env_block, main as deploy_cli
-from polyplace_contracts.deploy import DeployParams, Deployment, deploy
-
-from conftest import AnvilNode
+from polyplace_contracts.cli.deploy import _format_env_block
+from polyplace_contracts.cli.deploy import main as deploy_cli
+from polyplace_contracts.deploy import Deployment, DeployParams, deploy
 
 
 def _w3(node: AnvilNode) -> Web3:
@@ -179,7 +179,7 @@ def test_env_block_shell_quotes_rpc_url(tmp_path: Path) -> None:
             "-c",
             (
                 f". {shlex.quote(str(env_path))}; "
-                "printf '%s\\n%s\\n' \"$POLYPLACE_RPC_URL\" \"$POLYPLACE_START_BLOCK\""
+                'printf \'%s\\n%s\\n\' "$POLYPLACE_RPC_URL" "$POLYPLACE_START_BLOCK"'
             ),
         ],
         check=True,

--- a/packages/python/uv.lock
+++ b/packages/python/uv.lock
@@ -1085,6 +1085,11 @@ dev = [
     { name = "pytest" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.3.3" },
@@ -1093,6 +1098,9 @@ requires-dist = [
     { name = "web3", specifier = ">=6.0.0" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "ruff", specifier = ">=0.15.12" }]
 
 [[package]]
 name = "propcache"
@@ -1580,6 +1588,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1b/2d/439b0728a92964a04d9c88ea1ca9ebb128893fbbd5834faa31f987f2fd4c/rlp-4.1.0.tar.gz", hash = "sha256:be07564270a96f3e225e2c107db263de96b5bc1f27722d2855bd3459a08e95a9", size = 33429, upload-time = "2025-02-04T22:05:59.089Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/fb/e4c0ced9893b84ac95b7181d69a9786ce5879aeb3bbbcbba80a164f85d6a/rlp-4.1.0-py3-none-any.whl", hash = "sha256:8eca394c579bad34ee0b937aecb96a57052ff3716e19c7a578883e767bc5da6f", size = 19973, upload-time = "2025-02-04T22:05:57.05Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/python.yml` running ruff lint, ruff format-check, and pytest on push, PR, and manual dispatch — parallel to the existing Foundry workflow.
- Pins Foundry to `v1.5.1` (same version the Foundry workflow uses) so `anvil` is available for the deploy tests in `tests/test_deploy.py`.
- Adds Ruff dev dep + project config to `packages/python/pyproject.toml`: `line-length=100`, `target-version="py310"`, defaults + `I` (isort) + `UP` (pyupgrade).
- One-time formatting/import pass across the whole `packages/python`. No behaviour changes — pytest stays at 12 passing locally.

Commits are split: Ruff config & dev dep, the format-only pass, then the workflow itself, so the diff is easy to review.

Closes #17.

## Test plan
- [ ] CI runs both `Foundry project` and `Python package` jobs and both go green.
- [ ] `uv run ruff check .` clean.
- [ ] `uv run ruff format --check .` clean.
- [ ] `uv run pytest` — 12 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)