### PR TITLE
Add networks.py registry; shrink foundry.toml

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -6,13 +6,4 @@ remappings = [
     "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/",
 ]
 
-[rpc_endpoints]
-localhost = "http://localhost:8545"
-amoy      = "${AMOY_RPC_URL}"
-polygon   = "${POLYGON_RPC_URL}"
-
-[etherscan]
-amoy    = { key = "${POLYGONSCAN_API_KEY}", chain = 80002, url = "https://api-amoy.polygonscan.com/api" }
-polygon = { key = "${POLYGONSCAN_API_KEY}", chain = 137, url = "https://api.polygonscan.com/api" }
-
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/packages/python/polyplace_contracts/cli/deploy.py
+++ b/packages/python/polyplace_contracts/cli/deploy.py
@@ -13,6 +13,7 @@ from web3.middleware import ExtraDataToPOAMiddleware
 
 from polyplace_contracts import INITIAL_SUPPLY
 from polyplace_contracts.deploy import Deployment, DeployParams, deploy
+from polyplace_contracts.networks import get_network, resolve_rpc
 
 
 def _build_manifest(d: Deployment, name: str | None, created_at: str) -> dict:
@@ -47,7 +48,16 @@ def _format_env_block(d: Deployment, rpc_url: str) -> str:
 
 
 @click.command()
-@click.option("--rpc-url", required=True, help="JSON-RPC endpoint to deploy against.")
+@click.option(
+    "--network",
+    default=None,
+    help="Named network from polyplace_contracts.networks (e.g. localhost, amoy, polygon).",
+)
+@click.option(
+    "--rpc-url",
+    default=None,
+    help="JSON-RPC endpoint to deploy against. Mutually exclusive with --network.",
+)
 @click.option(
     "--private-key",
     required=True,
@@ -73,7 +83,8 @@ def _format_env_block(d: Deployment, rpc_url: str) -> str:
 @click.option("--rent-price", type=int, default=None, help="Cell rent price (token base units).")
 @click.option("--rent-duration", type=int, default=None, help="Cell rent duration (seconds).")
 def main(
-    rpc_url: str,
+    network: str | None,
+    rpc_url: str | None,
     private_key: str,
     manifest_out: Path | None,
     env_out: str | None,
@@ -85,16 +96,30 @@ def main(
 ) -> None:
     """Deploy PlaceToken / PlaceFaucet / PlaceGrid and seed the faucet.
 
+    Pass either --network <name> (resolved via polyplace_contracts.networks)
+    or --rpc-url <url> for an ad-hoc endpoint.
+
     By default the shell env block is written to stdout. To load it into
     your current shell:
 
     \b
-        eval "$(polyplace-deploy --rpc-url ... --private-key ...)"
+        eval "$(polyplace-deploy --network localhost --private-key ...)"
         # or
-        source <(polyplace-deploy --rpc-url ... --private-key ...)
+        source <(polyplace-deploy --network localhost --private-key ...)
 
     Pass --env-out PATH to write the block to a file instead.
     """
+    if (network is None) == (rpc_url is None):
+        raise click.UsageError("Pass exactly one of --network or --rpc-url.")
+
+    expected_chain_id: int | None = None
+    if network is not None:
+        try:
+            rpc_url = resolve_rpc(network)
+        except (ValueError, RuntimeError) as exc:
+            raise click.UsageError(str(exc)) from exc
+        expected_chain_id = get_network(network).chain_id
+
     overrides = {
         k: v
         for k, v in {
@@ -111,6 +136,14 @@ def main(
     if not w3.is_connected():
         raise click.ClickException(f"Cannot connect to RPC at {rpc_url}")
     w3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
+
+    if expected_chain_id is not None:
+        actual = w3.eth.chain_id
+        if actual != expected_chain_id:
+            raise click.ClickException(
+                f"network {network!r} expects chain id {expected_chain_id}, "
+                f"but RPC reports {actual}"
+            )
 
     deployment = deploy(w3, private_key, params)
     created_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/packages/python/polyplace_contracts/networks.py
+++ b/packages/python/polyplace_contracts/networks.py
@@ -1,0 +1,71 @@
+"""Single source of truth for chain metadata used by the Python CLIs."""
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Network:
+    name: str
+    chain_id: int
+    rpc_url: str | None
+    rpc_env: str | None
+    verifier_url: str | None
+    verifier_key_env: str | None
+
+
+NETWORKS: dict[str, Network] = {
+    "localhost": Network(
+        name="localhost",
+        chain_id=31337,
+        rpc_url="http://localhost:8545",
+        rpc_env=None,
+        verifier_url=None,
+        verifier_key_env=None,
+    ),
+    "amoy": Network(
+        name="amoy",
+        chain_id=80002,
+        rpc_url=None,
+        rpc_env="AMOY_RPC_URL",
+        verifier_url="https://api-amoy.polygonscan.com/api",
+        verifier_key_env="POLYGONSCAN_API_KEY",
+    ),
+    "polygon": Network(
+        name="polygon",
+        chain_id=137,
+        rpc_url=None,
+        rpc_env="POLYGON_RPC_URL",
+        verifier_url="https://api.polygonscan.com/api",
+        verifier_key_env="POLYGONSCAN_API_KEY",
+    ),
+}
+
+
+def get_network(name: str) -> Network:
+    try:
+        return NETWORKS[name]
+    except KeyError:
+        known = ", ".join(sorted(NETWORKS))
+        raise ValueError(f"unknown network {name!r}; known: {known}") from None
+
+
+def resolve_rpc(name: str) -> str:
+    net = get_network(name)
+    if net.rpc_url is not None:
+        return net.rpc_url
+    assert net.rpc_env is not None, f"network {name!r} has neither rpc_url nor rpc_env"
+    value = os.environ.get(net.rpc_env)
+    if not value:
+        raise RuntimeError(f"network {name!r} requires env var {net.rpc_env} to be set")
+    return value
+
+
+def resolve_verifier(name: str) -> tuple[str, str]:
+    net = get_network(name)
+    if net.verifier_url is None or net.verifier_key_env is None:
+        raise ValueError(f"network {name!r} has no verifier configured")
+    key = os.environ.get(net.verifier_key_env)
+    if not key:
+        raise RuntimeError(f"network {name!r} requires env var {net.verifier_key_env} to be set")
+    return net.verifier_url, key

--- a/packages/python/tests/test_networks.py
+++ b/packages/python/tests/test_networks.py
@@ -1,0 +1,71 @@
+"""Tests for `polyplace_contracts.networks`."""
+
+import pytest
+
+from polyplace_contracts.networks import (
+    NETWORKS,
+    get_network,
+    resolve_rpc,
+    resolve_verifier,
+)
+
+
+def test_networks_has_expected_keys() -> None:
+    assert set(NETWORKS) == {"localhost", "amoy", "polygon"}
+
+
+def test_get_network_returns_chain_id() -> None:
+    assert get_network("amoy").chain_id == 80002
+    assert get_network("polygon").chain_id == 137
+    assert get_network("localhost").chain_id == 31337
+
+
+def test_get_network_unknown_raises() -> None:
+    with pytest.raises(ValueError, match="unknown network"):
+        get_network("nonsense")
+
+
+def test_resolve_rpc_localhost_uses_literal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AMOY_RPC_URL", raising=False)
+    assert resolve_rpc("localhost") == "http://localhost:8545"
+
+
+def test_resolve_rpc_amoy_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AMOY_RPC_URL", "https://amoy.example/rpc")
+    assert resolve_rpc("amoy") == "https://amoy.example/rpc"
+
+
+def test_resolve_rpc_amoy_missing_env_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AMOY_RPC_URL", raising=False)
+    with pytest.raises(RuntimeError, match="AMOY_RPC_URL"):
+        resolve_rpc("amoy")
+
+
+def test_resolve_rpc_unknown_raises() -> None:
+    with pytest.raises(ValueError, match="unknown network"):
+        resolve_rpc("nonsense")
+
+
+def test_resolve_verifier_amoy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POLYGONSCAN_API_KEY", "secret-key")
+    url, key = resolve_verifier("amoy")
+    assert url == "https://api-amoy.polygonscan.com/api"
+    assert key == "secret-key"
+
+
+def test_resolve_verifier_polygon(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POLYGONSCAN_API_KEY", "secret-key")
+    url, key = resolve_verifier("polygon")
+    assert url == "https://api.polygonscan.com/api"
+    assert key == "secret-key"
+
+
+def test_resolve_verifier_missing_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("POLYGONSCAN_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="POLYGONSCAN_API_KEY"):
+        resolve_verifier("amoy")
+
+
+def test_resolve_verifier_localhost_raises() -> None:
+    with pytest.raises(ValueError, match="no verifier"):
+        resolve_verifier("localhost")


### PR DESCRIPTION
## Summary
- Add `polyplace_contracts/networks.py` with a `Network` dataclass + `NETWORKS` dict (`localhost`, `amoy`, `polygon`) and helpers `get_network`, `resolve_rpc`, `resolve_verifier`. Existing env var names (`AMOY_RPC_URL`, `POLYGON_RPC_URL`, `POLYGONSCAN_API_KEY`) are preserved.
- Strip `foundry.toml` to build config only — drop `[rpc_endpoints]` and `[etherscan]` (no Solidity script or `forge verify-contract` step depends on them now that deployment lives in Python).
- `polyplace-deploy` gains `--network <name>` as an alternative to `--rpc-url`. When `--network` is given, the URL is resolved via the registry and the connected chain id is asserted to match before deploying. `--rpc-url` continues to work for ad-hoc cases; the two are mutually exclusive.

Out of scope (matches the issue's plan): the `justfile` `dev` recipe still has its own `chainId → RPC_URL` case — left as-is because `polyplace-dev` and the justfile wrapper are migrating to the planned `polyplace-client` repo. The verify CLI itself is #11.

Closes #12

## Test plan
- [x] `forge build` and `forge test` still pass after the `foundry.toml` shrink (74 tests).
- [x] `pytest` passes — 24 tests, including 11 new in `tests/test_networks.py` covering registry keys, env-driven vs literal RPC resolution, missing-env errors, verifier URL/key resolution, no-verifier-on-localhost, and unknown-network errors.
- [x] `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)