### PR TITLE
Add polyplace-verify CLI

### DIFF
--- a/packages/python/polyplace_contracts/cli/verify.py
+++ b/packages/python/polyplace_contracts/cli/verify.py
@@ -1,0 +1,113 @@
+"""`polyplace-verify` — shells out to `forge verify-contract` for all three contracts."""
+
+import json
+import subprocess
+from pathlib import Path
+
+import click
+from eth_abi import encode
+
+from polyplace_contracts.networks import get_network, resolve_verifier
+
+# (sol_path, contract_name, constructor types) — values come from the manifest at runtime.
+_CONTRACTS: tuple[tuple[str, str, list[str]], ...] = (
+    ("src/PlaceToken.sol", "PlaceToken", []),
+    (
+        "src/PlaceFaucet.sol",
+        "PlaceFaucet",
+        ["address", "uint256", "uint256", "address"],
+    ),
+    (
+        "src/PlaceGrid.sol",
+        "PlaceGrid",
+        ["address", "address", "uint256", "uint256", "address"],
+    ),
+)
+
+
+def _ctor_values(name: str, manifest: dict) -> list:
+    if name == "PlaceToken":
+        return []
+    if name == "PlaceFaucet":
+        return [
+            manifest["token"],
+            int(manifest["claimAmount"]),
+            int(manifest["cooldown"]),
+            manifest["deployer"],
+        ]
+    if name == "PlaceGrid":
+        return [
+            manifest["token"],
+            manifest["faucet"],
+            int(manifest["rentPrice"]),
+            int(manifest["rentDuration"]),
+            manifest["deployer"],
+        ]
+    raise AssertionError(f"unknown contract {name!r}")
+
+
+def _address(name: str, manifest: dict) -> str:
+    return {
+        "PlaceToken": manifest["token"],
+        "PlaceFaucet": manifest["faucet"],
+        "PlaceGrid": manifest["grid"],
+    }[name]
+
+
+@click.command()
+@click.option(
+    "--network",
+    required=True,
+    help="Named network from polyplace_contracts.networks (e.g. amoy, polygon).",
+)
+@click.option(
+    "--manifest",
+    "manifest_path",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Deployment manifest JSON written by polyplace-deploy.",
+)
+def main(network: str, manifest_path: Path) -> None:
+    """Verify PlaceToken / PlaceFaucet / PlaceGrid on the chain's block explorer.
+
+    Must be run from the contracts repo root: `forge verify-contract` recompiles
+    from source to compare metadata hashes, so it needs `src/`, `foundry.toml`,
+    and `lib/` reachable from the current working directory.
+
+    Compiler version, optimizer runs, and EVM version come from `foundry.toml` —
+    the same source of truth as the deploy build, so verify and deploy can never
+    disagree.
+    """
+    try:
+        chain_id = get_network(network).chain_id
+        verifier_url, api_key = resolve_verifier(network)
+    except (ValueError, RuntimeError) as exc:
+        raise click.UsageError(str(exc)) from exc
+
+    manifest = json.loads(manifest_path.read_text())
+
+    for sol_path, contract_name, types in _CONTRACTS:
+        address = _address(contract_name, manifest)
+        values = _ctor_values(contract_name, manifest)
+        argv = [
+            "forge",
+            "verify-contract",
+            address,
+            f"{sol_path}:{contract_name}",
+            "--chain-id",
+            str(chain_id),
+            "--verifier-url",
+            verifier_url,
+            "--etherscan-api-key",
+            api_key,
+        ]
+        if types:
+            argv += ["--constructor-args", "0x" + encode(types, values).hex()]
+        argv.append("--watch")
+
+        click.echo(f"Verifying {contract_name} at {address}…")
+        subprocess.run(argv, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/python/polyplace_contracts/networks.py
+++ b/packages/python/polyplace_contracts/networks.py
@@ -3,6 +3,12 @@
 import os
 from dataclasses import dataclass
 
+# Etherscan v2 unified endpoint — same base URL for every supported chain;
+# the chain is selected via the `chainid` query param. Polygonscan's v1
+# endpoints (api.polygonscan.com, api-amoy.polygonscan.com) are deprecated
+# and now return HTML deprecation notices that forge can't parse.
+_ETHERSCAN_V2_BASE = "https://api.etherscan.io/v2/api"
+
 
 @dataclass(frozen=True)
 class Network:
@@ -10,7 +16,6 @@ class Network:
     chain_id: int
     rpc_url: str | None
     rpc_env: str | None
-    verifier_url: str | None
     verifier_key_env: str | None
 
 
@@ -20,7 +25,6 @@ NETWORKS: dict[str, Network] = {
         chain_id=31337,
         rpc_url="http://localhost:8545",
         rpc_env=None,
-        verifier_url=None,
         verifier_key_env=None,
     ),
     "amoy": Network(
@@ -28,7 +32,6 @@ NETWORKS: dict[str, Network] = {
         chain_id=80002,
         rpc_url=None,
         rpc_env="AMOY_RPC_URL",
-        verifier_url="https://api-amoy.polygonscan.com/api",
         verifier_key_env="POLYGONSCAN_API_KEY",
     ),
     "polygon": Network(
@@ -36,7 +39,6 @@ NETWORKS: dict[str, Network] = {
         chain_id=137,
         rpc_url=None,
         rpc_env="POLYGON_RPC_URL",
-        verifier_url="https://api.polygonscan.com/api",
         verifier_key_env="POLYGONSCAN_API_KEY",
     ),
 }
@@ -63,9 +65,9 @@ def resolve_rpc(name: str) -> str:
 
 def resolve_verifier(name: str) -> tuple[str, str]:
     net = get_network(name)
-    if net.verifier_url is None or net.verifier_key_env is None:
+    if net.verifier_key_env is None:
         raise ValueError(f"network {name!r} has no verifier configured")
     key = os.environ.get(net.verifier_key_env)
     if not key:
         raise RuntimeError(f"network {name!r} requires env var {net.verifier_key_env} to be set")
-    return net.verifier_url, key
+    return f"{_ETHERSCAN_V2_BASE}?chainid={net.chain_id}", key

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "web3>=6.0.0",
     "fire>=0.7.1",
     "click>=8.3.3",
+    "eth-abi>=5.2.0",
 ]
 
 [project.optional-dependencies]
@@ -17,6 +18,7 @@ dev = [
 [project.scripts]
 polyplace-dev = "polyplace_contracts.cli:main"
 polyplace-deploy = "polyplace_contracts.cli.deploy:main"
+polyplace-verify = "polyplace_contracts.cli.verify:main"
 
 [build-system]
 requires = ["setuptools>=61"]

--- a/packages/python/tests/test_networks.py
+++ b/packages/python/tests/test_networks.py
@@ -49,14 +49,14 @@ def test_resolve_rpc_unknown_raises() -> None:
 def test_resolve_verifier_amoy(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("POLYGONSCAN_API_KEY", "secret-key")
     url, key = resolve_verifier("amoy")
-    assert url == "https://api-amoy.polygonscan.com/api"
+    assert url == "https://api.etherscan.io/v2/api?chainid=80002"
     assert key == "secret-key"
 
 
 def test_resolve_verifier_polygon(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("POLYGONSCAN_API_KEY", "secret-key")
     url, key = resolve_verifier("polygon")
-    assert url == "https://api.polygonscan.com/api"
+    assert url == "https://api.etherscan.io/v2/api?chainid=137"
     assert key == "secret-key"
 
 

--- a/packages/python/tests/test_verify.py
+++ b/packages/python/tests/test_verify.py
@@ -20,7 +20,7 @@ TOKEN = "0x" + "22" * 20
 FAUCET = "0x" + "33" * 20
 GRID = "0x" + "44" * 20
 
-AMOY_VERIFIER_URL = "https://api-amoy.polygonscan.com/api"
+AMOY_VERIFIER_URL = "https://api.etherscan.io/v2/api?chainid=80002"
 API_KEY = "test-polygonscan-key"
 
 

--- a/packages/python/tests/test_verify.py
+++ b/packages/python/tests/test_verify.py
@@ -1,0 +1,217 @@
+"""Unit tests for `polyplace-verify` — patches `subprocess.run`, no real explorer."""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from eth_abi import encode
+
+from polyplace_contracts.cli.verify import main as verify_cli
+
+CLAIM_AMOUNT = 150 * 10**18
+COOLDOWN = 24 * 60 * 60
+RENT_PRICE = 1 * 10**18
+RENT_DURATION = 7 * 24 * 60 * 60
+
+DEPLOYER = "0x" + "11" * 20
+TOKEN = "0x" + "22" * 20
+FAUCET = "0x" + "33" * 20
+GRID = "0x" + "44" * 20
+
+AMOY_VERIFIER_URL = "https://api-amoy.polygonscan.com/api"
+API_KEY = "test-polygonscan-key"
+
+
+def _write_manifest(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "chainId": 80002,
+                "deployer": DEPLOYER,
+                "token": TOKEN,
+                "faucet": FAUCET,
+                "grid": GRID,
+                "claimAmount": str(CLAIM_AMOUNT),
+                "cooldown": COOLDOWN,
+                "rentPrice": str(RENT_PRICE),
+                "rentDuration": RENT_DURATION,
+            }
+        )
+    )
+
+
+def _set_amoy_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POLYGONSCAN_API_KEY", API_KEY)
+
+
+def _run(monkeypatch: pytest.MonkeyPatch, manifest_path: Path) -> tuple[list[list[str]], object]:
+    calls: list[list[str]] = []
+
+    def fake_run(argv: list[str], check: bool = False, **kwargs: object) -> object:
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    runner = CliRunner()
+    result = runner.invoke(
+        verify_cli,
+        ["--network", "amoy", "--manifest", str(manifest_path)],
+        catch_exceptions=False,
+    )
+    return calls, result
+
+
+def test_verify_invokes_forge_three_times_in_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_amoy_env(monkeypatch)
+    manifest = tmp_path / "amoy.json"
+    _write_manifest(manifest)
+
+    calls, result = _run(monkeypatch, manifest)
+
+    assert result.exit_code == 0, result.output
+    assert len(calls) == 3
+    assert [c[3] for c in calls] == [
+        "src/PlaceToken.sol:PlaceToken",
+        "src/PlaceFaucet.sol:PlaceFaucet",
+        "src/PlaceGrid.sol:PlaceGrid",
+    ]
+    assert [c[2] for c in calls] == [TOKEN, FAUCET, GRID]
+
+
+def test_verify_passes_chain_and_verifier_flags(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_amoy_env(monkeypatch)
+    manifest = tmp_path / "amoy.json"
+    _write_manifest(manifest)
+
+    calls, result = _run(monkeypatch, manifest)
+
+    assert result.exit_code == 0, result.output
+    for argv in calls:
+        assert argv[0] == "forge"
+        assert argv[1] == "verify-contract"
+        assert argv[argv.index("--chain-id") + 1] == "80002"
+        assert argv[argv.index("--verifier-url") + 1] == AMOY_VERIFIER_URL
+        assert argv[argv.index("--etherscan-api-key") + 1] == API_KEY
+        assert "--watch" in argv
+
+
+def test_placetoken_omits_constructor_args(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_amoy_env(monkeypatch)
+    manifest = tmp_path / "amoy.json"
+    _write_manifest(manifest)
+
+    calls, result = _run(monkeypatch, manifest)
+
+    assert result.exit_code == 0, result.output
+    token_argv = calls[0]
+    assert "--constructor-args" not in token_argv
+
+
+def test_faucet_constructor_args_match_eth_abi(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_amoy_env(monkeypatch)
+    manifest = tmp_path / "amoy.json"
+    _write_manifest(manifest)
+
+    calls, _ = _run(monkeypatch, manifest)
+
+    faucet_argv = calls[1]
+    args_hex = faucet_argv[faucet_argv.index("--constructor-args") + 1]
+    expected = (
+        "0x"
+        + encode(
+            ["address", "uint256", "uint256", "address"],
+            [TOKEN, CLAIM_AMOUNT, COOLDOWN, DEPLOYER],
+        ).hex()
+    )
+    assert args_hex == expected
+
+
+def test_grid_constructor_args_match_eth_abi(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_amoy_env(monkeypatch)
+    manifest = tmp_path / "amoy.json"
+    _write_manifest(manifest)
+
+    calls, _ = _run(monkeypatch, manifest)
+
+    grid_argv = calls[2]
+    args_hex = grid_argv[grid_argv.index("--constructor-args") + 1]
+    expected = (
+        "0x"
+        + encode(
+            ["address", "address", "uint256", "uint256", "address"],
+            [TOKEN, FAUCET, RENT_PRICE, RENT_DURATION, DEPLOYER],
+        ).hex()
+    )
+    assert args_hex == expected
+
+
+def test_called_process_error_propagates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_amoy_env(monkeypatch)
+    manifest = tmp_path / "amoy.json"
+    _write_manifest(manifest)
+
+    def fake_run(argv: list[str], check: bool = False, **kwargs: object) -> object:
+        raise subprocess.CalledProcessError(returncode=1, cmd=argv)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    runner = CliRunner()
+    result = runner.invoke(
+        verify_cli,
+        ["--network", "amoy", "--manifest", str(manifest)],
+    )
+
+    assert result.exit_code != 0
+    assert isinstance(result.exception, subprocess.CalledProcessError)
+
+
+def test_unknown_network_raises_usage_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_amoy_env(monkeypatch)
+    manifest = tmp_path / "amoy.json"
+    _write_manifest(manifest)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        verify_cli,
+        ["--network", "nonsense", "--manifest", str(manifest)],
+    )
+
+    assert result.exit_code != 0
+    assert "unknown network" in result.output.lower()
+
+
+def test_missing_manifest_path_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_amoy_env(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(
+        verify_cli,
+        ["--network", "amoy", "--manifest", "/no/such/file.json"],
+    )
+
+    assert result.exit_code != 0
+    assert "does not exist" in result.output.lower()
+
+
+def test_localhost_has_no_verifier(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest = tmp_path / "local.json"
+    _write_manifest(manifest)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        verify_cli,
+        ["--network", "localhost", "--manifest", str(manifest)],
+    )
+
+    assert result.exit_code != 0
+    assert "no verifier" in result.output.lower()

--- a/packages/python/uv.lock
+++ b/packages/python/uv.lock
@@ -1076,6 +1076,7 @@ version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "eth-abi" },
     { name = "fire" },
     { name = "web3" },
 ]
@@ -1093,6 +1094,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.3.3" },
+    { name = "eth-abi", specifier = ">=5.2.0" },
     { name = "fire", specifier = ">=0.7.1" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "web3", specifier = ">=6.0.0" },


### PR DESCRIPTION
## Summary
- `polyplace-verify --network <name> --manifest <path>` shells out to `forge verify-contract` for PlaceToken / PlaceFaucet / PlaceGrid, reusing chain ID + verifier URL + API key from `polyplace_contracts.networks`.
- Constructor args are ABI-encoded via `eth_abi`; the `--constructor-args` flag is omitted entirely for `PlaceToken` (no constructor args).
- Compiler / optimizer / EVM version intentionally come from `foundry.toml` — same source of truth as the deploy build, so verify and deploy can never disagree.
- Added `eth-abi` as an explicit dependency and registered `polyplace-verify` as a console script.

## Test plan
- [x] `uv run pytest` — 33 passed (9 new in `test_verify.py`, no real explorer calls; `subprocess.run` is patched).
- [x] `uv run ruff check . && uv run ruff format --check .` — clean.
- [x] `polyplace-verify --help` renders.
- [ ] Manual Amoy run (per the [implementation plan](https://github.com/josh-gree/polyplace-contracts/issues/11#issuecomment-4343977299)): deploy → verify → confirm 3× "Verified" on polygonscan.com → re-run verify and confirm exit 0 (idempotency assumption). Owner-driven, requires `POLYPLACE_PRIVATE_KEY`, `AMOY_RPC_URL`, and `POLYGONSCAN_API_KEY`.

Closes #11