### PR TITLE
Track deploy nonce locally to survive RPC eventual consistency

### DIFF
--- a/packages/python/polyplace_contracts/deploy.py
+++ b/packages/python/polyplace_contracts/deploy.py
@@ -68,13 +68,19 @@ def deploy(
     account: LocalAccount = Account.from_key(deployer_key)
     deployer = account.address
     chain_id = w3.eth.chain_id
+    # Track nonce locally instead of re-querying after each send. Public
+    # RPCs (e.g. Amoy) are load-balanced and eventually consistent — a read
+    # immediately after a mined tx can hit a backend that hasn't seen the
+    # new block yet, returning a stale count and triggering "nonce too low".
+    nonce = w3.eth.get_transaction_count(deployer, "pending")
 
     def _send(builder: Any) -> tuple[str, dict[str, Any]]:
+        nonlocal nonce
         tx = builder.build_transaction(
             {
                 "from": deployer,
                 "chainId": chain_id,
-                "nonce": w3.eth.get_transaction_count(deployer),
+                "nonce": nonce,
             }
         )
         signed = account.sign_transaction(tx)
@@ -82,6 +88,7 @@ def deploy(
         receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
         if receipt.status != 1:
             raise RuntimeError(f"Transaction {tx_hash.hex()} reverted")
+        nonce += 1
         return tx_hash.hex(), receipt
 
     def _deploy(abi: list, bytecode: str, *args: Any) -> tuple[str, str, dict[str, Any]]:


### PR DESCRIPTION
## Summary
- Fixes `nonce too low: next nonce N, tx nonce N-1` failure on Amoy mid-deploy.
- Public RPCs (Amoy, Polygon mainnet, etc.) are load-balanced and eventually consistent — `w3.eth.get_transaction_count(deployer)` issued right after `wait_for_transaction_receipt` can hit a backend that hasn't observed the new block yet, returning a stale count. The next tx then reuses the prior nonce and the node rejects it.
- Fetch the nonce once at `"pending"` at the top of `deploy()` and increment locally after each send.

## Test plan
- [x] `uv run pytest` — 24 passed (existing Anvil tests still green; Anvil is single-node so it never exercised the race, but local-tracking is a strict superset of behavior on a single-node chain).
- [x] `uv run ruff check . && uv run ruff format --check .` — clean.
- [ ] Re-run `polyplace-deploy --network amoy …` end-to-end, confirm all four txs (token / faucet / grid / transfer) land without a nonce error.

## Notes
The PlaceToken from the failed Amoy attempt is now an orphaned contract (no faucet/grid wired to it). Stakes are low; leaving it on chain.